### PR TITLE
Updates broken links to  AI-secure/DecodingTrust repo on the index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,31 +132,31 @@
                         To run the evaluation, go the corresponding subdirectories for evaluation.
                         <ul class="list-unstyled">
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/toxicity">Toxicity
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/src/dt/perspectives/toxicity">Toxicity
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/stereotype">Stereotype
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/src/dt/perspectives/stereotype">Stereotype
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/adv-glue-plus-plus">Adversarial
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/src/dt/perspectives/advglue">Adversarial
                                 Robustness
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/ood">Out-of-distribution
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/src/dt/perspectives/ood">Out-of-distribution
                                 Robustness
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/adv_demonstration">Robustness
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/src/dt/perspectives/adv_demonstration">Robustness
                                 against Adversarial Demonstrations
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/privacy">Privacy
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/src/dt/perspectives/privacy">Privacy
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/machine_ethics">Machine Ethics
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/src/dt/perspectives/machine_ethics">Machine Ethics
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/fairness">Fairness
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/src/dt/perspectives/fairness">Fairness
                             </a></li>
                         </ul>
                         </p><p>While our evaluation mainly focuses on GPT-3.5 and GPT-4,

--- a/index.html
+++ b/index.html
@@ -132,31 +132,31 @@
                         To run the evaluation, go the corresponding subdirectories for evaluation.
                         <ul class="list-unstyled">
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/toxicity">Toxicity
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/toxicity">Toxicity
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/stereotype">Stereotype
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/stereotype">Stereotype
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/adv-glue-plus-plus">Adversarial
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/adv-glue-plus-plus">Adversarial
                                 Robustness
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/ood">Out-of-distribution
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/ood">Out-of-distribution
                                 Robustness
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/adv_demo">Robustness
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/adv_demonstration">Robustness
                                 against Adversarial Demonstrations
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/privacy">Privacy
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/privacy">Privacy
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/machine_ethics">Machine Ethics
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/machine_ethics">Machine Ethics
                             </a></li>
                             <li><a class="btn actionBtn inverseBtn"
-                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/fairness">Fairness
+                                   href="https://github.com/AI-secure/DecodingTrust/tree/main/data/fairness">Fairness
                             </a></li>
                         </ul>
                         </p><p>While our evaluation mainly focuses on GPT-3.5 and GPT-4,


### PR DESCRIPTION
I noticed the links are broken on the index page. Seems that the structure of the AI-secure/DecodingTrust repo changed and caused the broken links. 

This PR updates those links. 